### PR TITLE
Feat(#55)/cadastro aviso

### DIFF
--- a/app/backend/spothood/condominium/models.py
+++ b/app/backend/spothood/condominium/models.py
@@ -40,7 +40,7 @@ class Pessoa(models.Model):
     data_nascimento = models.DateField(null=False)
 
 class Condominio(models.Model):
-    cpf = models.ForeignKey('Pessoa', on_delete=models.RESTRICT)
+    cpf = models.ForeignKey(Pessoa, on_delete=models.RESTRICT, verbose_name=('cpf'))
     cnpj = models.CharField(primary_key=True, max_length=18, null=False) 
     nome_fantasia = models.CharField(max_length=150, null=False)
 

--- a/app/backend/spothood/condominium/models.py
+++ b/app/backend/spothood/condominium/models.py
@@ -1,5 +1,34 @@
 from django.db import models
 
+ESTADOS = (
+    ('AC','Acre'),
+    ('AL','Alagoas'),
+    ('AP','Amapá'),
+    ('AM','Amazonas'),
+    ('BA','Bahia'),
+    ('CE','Ceará'),
+    ('DF','Distrito Federal'),
+    ('ES','Espírito Santo'),
+    ('GO','Goiás'),
+    ('MA','Maranhão'),
+    ('MT','Mato Grosso'),
+    ('MS','Mato Grosso do Sul'),
+    ('MG','Minas Gerais'),
+    ('PA','Pará'),
+    ('PB','Paraíba'),
+    ('PR','Paraná'),
+    ('PE','Pernambuco'),
+    ('PI','Piauí'),
+    ('RJ','Rio de Janeiro'),
+    ('RN','Rio Grande do Norte'),
+    ('RS','Rio Grande do Sul'),
+    ('RO','Rondônia'),
+    ('RR','Roraima'),
+    ('SC','Santa Catarina'),
+    ('SP','São Paulo'),
+    ('SE','Sergipe'),
+    ('TO','Tocantins')
+)
 
 class Pessoa(models.Model):
     cpf = models.CharField(primary_key=True, max_length=14, null=False)
@@ -9,3 +38,15 @@ class Pessoa(models.Model):
     senha = models.CharField(max_length=250, null=False)
     sexo = models.CharField(max_length=1,choices=(('M', 'Masculino'),('F', 'Feminino')))
     data_nascimento = models.DateField(null=False)
+
+class Condominio(models.Model):
+    cpf = models.ForeignKey('Pessoa', on_delete=models.RESTRICT)
+    cnpj = models.CharField(primary_key=True, max_length=18, null=False) 
+    nome_fantasia = models.CharField(max_length=150, null=False)
+
+    cep = models.CharField(max_length=9,null=False) 
+    numero = models.IntegerField(null=False)
+    rua = models.CharField(max_length=250, null=False)
+    bairro = models.CharField(max_length=250, null=False)
+    cidade = models.CharField(max_length=150, null=False)
+    estado = models.CharField(max_length=2,choices=ESTADOS)

--- a/app/backend/spothood/condominium/models.py
+++ b/app/backend/spothood/condominium/models.py
@@ -40,8 +40,8 @@ class Pessoa(models.Model):
     data_nascimento = models.DateField(null=False)
 
 class Condominio(models.Model):
-    cpf = models.ForeignKey(Pessoa, on_delete=models.RESTRICT, verbose_name=('cpf'))
     cnpj = models.CharField(primary_key=True, max_length=18, null=False) 
+    cpf = models.ForeignKey(Pessoa, on_delete=models.RESTRICT, verbose_name=('cpf'))
     nome_fantasia = models.CharField(max_length=150, null=False)
 
     cep = models.CharField(max_length=9,null=False) 
@@ -50,3 +50,11 @@ class Condominio(models.Model):
     bairro = models.CharField(max_length=250, null=False)
     cidade = models.CharField(max_length=150, null=False)
     estado = models.CharField(max_length=2,choices=ESTADOS)
+
+class Aviso(models.Model):
+    idAviso = models.AutoField(primary_key=True) 
+    cnpj = models.ForeignKey(Condominio, on_delete=models.RESTRICT, verbose_name=('cnpj'))
+
+    titulo = models.CharField(max_length=75, null=False)
+    descricao = models.CharField(max_length=500, null=False)
+    data_cadastro = models.DateTimeField(auto_now_add=True,null=False)

--- a/app/backend/spothood/condominium/serializers.py
+++ b/app/backend/spothood/condominium/serializers.py
@@ -1,53 +1,46 @@
 from rest_framework import serializers
 from .models import Pessoa, Condominio
-from django.db import models
 
-import re
-from datetime import datetime
+from .validacao import Validador
 
 class PessoaSerializer(serializers.HyperlinkedModelSerializer):
     def validate_nome(self,value):
         value = value.strip()
-        quantia_digitos = len(re.findall(r'\d+',value))
 
-        if  quantia_digitos > 0:
+        if not Validador.nome_valido(value):
             raise serializers.ValidationError("Nome inválido, não devem existir números em nomes.")
         
         return value
 
     def validate_cpf(self,value):
         value = value.strip()
-        cpf_valido = re.findall(r'^\d{3}\.\d{3}\.\d{3}-\d{2}$',value)
 
-        if not cpf_valido:
-            raise serializers.ValidationError("Cpf inválido, formato não aceito.")
+        if not Validador.cpf_valido(value):
+            raise serializers.ValidationError("Cpf inválido, formato aceito: [XXX.XXX.XXX-XX].")
         
         return value
 
     def validate_email(self,value):
         value = value.strip()
-        email_valido = re.findall(r'^.+@[a-zA-Z]+\.[a-zA-Z]+$',value)
 
-        if not email_valido:
-            raise serializers.ValidationError("E-mail inválido, formato não aceito.")
+        if not Validador.email_valido(value):
+            raise serializers.ValidationError("E-mail inválido, formato  aceito: [algo@dominio_sem_numero.palavra_sem_numero].")
         
         return value
 
     def validate_telefone(self,value):
         value = value.strip()
-        telefone_valido = re.findall(r'^\(\d{2}\)\ \d{5}-\d{4}$',value)
 
-        if not telefone_valido:
-            raise serializers.ValidationError("Telefone inválido, formato não aceito.")
+        if not Validador.telefone_valido(value):
+            raise serializers.ValidationError("Telefone inválido, formato aceito:[(XX) XXXXX-XXXX].")
         
         return value
 
     def validate_data_nascimento(self,value):
-        hoje = datetime.now().strftime("%Y-%m-%d")
         value = value.strftime("%Y-%m-%d")
 
-        if hoje < value:
-            raise serializers.ValidationError("Data inválida, impossível criar usuário que não nasceu ainda.")
+        if not Validador.data_nascimento_valida(value):
+            raise serializers.ValidationError("Data inválida, impossível inserir usuário que não nasceu ainda.")
         
         return value
 
@@ -65,8 +58,23 @@ class PessoaSerializer(serializers.HyperlinkedModelSerializer):
         
         
 class CondominioSerializer(serializers.ModelSerializer):
-    #pessoa = models.ForeignKey(Pessoa, on_delete=models.SET_NULL)
-    #cpf = serializers.SlugRelatedField(read_only=True, slug_field='cpf')
+    def validate_cnpj(self,value):
+        value = value.strip()
+
+        if not Validador.cnpj_valido(value):
+            raise serializers.ValidationError("Cnpj inválido, formato aceito: [XX.XXX.XXX/000D-XX]. D assume 1 ou 2.")
+        return value
+
+    def validate_cep(self,value):
+        value = value.strip()
+        if not Validador.cep_valido(value):
+            raise serializers.ValidationError("Cep inválido, formato aceito: [XXXXX-XXX].")
+        return value
+
+    def validate_numero(self,value):
+        if not Validador.numero_valido(value):
+            raise serializers.ValidationError("Numero inválido, digite um valor não negativo.")
+        return value
 
     class Meta:
         model = Condominio

--- a/app/backend/spothood/condominium/serializers.py
+++ b/app/backend/spothood/condominium/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Pessoa
+from .models import Pessoa, Condominio
 
 import re
 from datetime import datetime
@@ -63,3 +63,16 @@ class PessoaSerializer(serializers.HyperlinkedModelSerializer):
                 )
         
         
+class CondominioSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Condominio
+        fields = ('cpf', 
+                   'cnpj', 
+                   'nome_fantasia', 
+                   'cep', 
+                   'numero', 
+                   'rua', 
+                   'bairro', 
+                   'cidade', 
+                   'estado' 
+                )

--- a/app/backend/spothood/condominium/serializers.py
+++ b/app/backend/spothood/condominium/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Pessoa, Condominio
+from .models import Pessoa, Condominio, Aviso
 
 from .validacao import Validador
 
@@ -7,7 +7,7 @@ class PessoaSerializer(serializers.HyperlinkedModelSerializer):
     def validate_nome(self,value):
         value = value.strip()
 
-        if not Validador.nome_valido(value):
+        if Validador.possui_digito(value):
             raise serializers.ValidationError("Nome inválido, não devem existir números em nomes.")
         
         return value
@@ -87,4 +87,15 @@ class CondominioSerializer(serializers.ModelSerializer):
                    'bairro', 
                    'cidade', 
                    'estado' 
+                )
+
+class AvisoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Aviso
+        fields = ( 
+                'cnpj',
+                'idAviso',
+                'titulo',
+                'descricao',
+                'data_cadastro'
                 )

--- a/app/backend/spothood/condominium/serializers.py
+++ b/app/backend/spothood/condominium/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import Pessoa, Condominio
+from django.db import models
 
 import re
 from datetime import datetime
@@ -63,10 +64,13 @@ class PessoaSerializer(serializers.HyperlinkedModelSerializer):
                 )
         
         
-class CondominioSerializer(serializers.HyperlinkedModelSerializer):
+class CondominioSerializer(serializers.ModelSerializer):
+    #pessoa = models.ForeignKey(Pessoa, on_delete=models.SET_NULL)
+    #cpf = serializers.SlugRelatedField(read_only=True, slug_field='cpf')
+
     class Meta:
         model = Condominio
-        fields = ('cpf', 
+        fields = ( 'cpf',
                    'cnpj', 
                    'nome_fantasia', 
                    'cep', 

--- a/app/backend/spothood/condominium/urls.py
+++ b/app/backend/spothood/condominium/urls.py
@@ -1,8 +1,7 @@
 from rest_framework import routers
 
-from .views import PessoaViewSet
-
-app_name = "pessoa"
+from .views import PessoaViewSet, CondominioViewSet
 
 router = routers.DefaultRouter()
 router.register(r'pessoa', PessoaViewSet)
+router.register(r'condominio', CondominioViewSet)

--- a/app/backend/spothood/condominium/urls.py
+++ b/app/backend/spothood/condominium/urls.py
@@ -1,7 +1,8 @@
 from rest_framework import routers
 
-from .views import PessoaViewSet, CondominioViewSet
+from .views import PessoaViewSet, CondominioViewSet, AvisoViewSet
 
 router = routers.DefaultRouter()
 router.register(r'pessoa', PessoaViewSet)
 router.register(r'condominio', CondominioViewSet)
+router.register(r'aviso', AvisoViewSet)

--- a/app/backend/spothood/condominium/validacao.py
+++ b/app/backend/spothood/condominium/validacao.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+import re
+
+class Validador:
+
+    @staticmethod
+    def nome_valido(nome: str) -> bool:
+
+        quantia_digitos = len(re.findall(r'\d+',nome))
+
+        if  quantia_digitos > 0:
+            return False
+
+        return True
+
+    @staticmethod
+    def cpf_valido(cpf: str) -> bool:
+
+        cpf_valido = re.findall(r'^\d{3}\.\d{3}\.\d{3}-\d{2}$',cpf)
+
+        if not cpf_valido:
+            return False
+
+        return True
+
+    @staticmethod
+    def email_valido(email: str) -> bool:
+        email_valido = re.findall(r'^.+@[a-zA-Z]+\.[a-zA-Z]+$',email)
+
+        if not email_valido:
+            return False
+
+        return True
+
+    @staticmethod
+    def telefone_valido(telefone: str) -> bool:
+        telefone_valido = re.findall(r'^\(\d{2}\)\ \d{5}-\d{4}$',telefone)
+
+        if not telefone_valido:
+            return False
+
+        return True
+
+    @staticmethod
+    def data_nascimento_valida(data_nascimento: str) -> bool:
+        hoje = datetime.now().strftime("%Y-%m-%d")
+
+        if hoje < data_nascimento:
+            return False
+
+        return True
+
+    @staticmethod
+    def cnpj_valido(cnpj: str) -> bool:
+        cnpj_valido = re.findall(r'^\d{2}\.\d{3}\.\d{3}\/000[12]-\d{2}$',cnpj)
+
+        if not cnpj_valido:
+            return False
+
+        return True
+    @staticmethod
+    def cep_valido(cep: str) -> bool:
+        cep_valido = re.findall(r'^\d{5}-\d{3}$',cep)
+
+        if not cep_valido:
+            return False
+
+        return True
+
+    @staticmethod
+    def numero_valido(numero: int) -> bool:
+
+        if numero > 0:
+            return True
+
+        return False

--- a/app/backend/spothood/condominium/validacao.py
+++ b/app/backend/spothood/condominium/validacao.py
@@ -4,14 +4,14 @@ import re
 class Validador:
 
     @staticmethod
-    def nome_valido(nome: str) -> bool:
+    def possui_digito(st: str) -> bool:
 
-        quantia_digitos = len(re.findall(r'\d+',nome))
+        quantia_digitos = len(re.findall(r'\d+',st))
 
         if  quantia_digitos > 0:
-            return False
+            return True
 
-        return True
+        return False
 
     @staticmethod
     def cpf_valido(cpf: str) -> bool:

--- a/app/backend/spothood/condominium/views.py
+++ b/app/backend/spothood/condominium/views.py
@@ -1,9 +1,14 @@
 from rest_framework import viewsets
 from rest_framework import permissions
-from .models import Pessoa
-from .serializers import PessoaSerializer
+from .models import Pessoa, Condominio
+from .serializers import PessoaSerializer, CondominioSerializer
 
 class PessoaViewSet(viewsets.ModelViewSet):
     queryset = Pessoa.objects.all()
     serializer_class = PessoaSerializer
+    permission_classes = (permissions.AllowAny,)
+
+class CondominioViewSet(viewsets.ModelViewSet):
+    queryset = Condominio.objects.all()
+    serializer_class = CondominioSerializer
     permission_classes = (permissions.AllowAny,)

--- a/app/backend/spothood/condominium/views.py
+++ b/app/backend/spothood/condominium/views.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
 from rest_framework import permissions
-from .models import Pessoa, Condominio
-from .serializers import PessoaSerializer, CondominioSerializer
+from .models import Pessoa, Condominio, Aviso
+from .serializers import PessoaSerializer, CondominioSerializer, AvisoSerializer
 
 class PessoaViewSet(viewsets.ModelViewSet):
     queryset = Pessoa.objects.all()
@@ -11,4 +11,9 @@ class PessoaViewSet(viewsets.ModelViewSet):
 class CondominioViewSet(viewsets.ModelViewSet):
     queryset = Condominio.objects.all()
     serializer_class = CondominioSerializer
+    permission_classes = (permissions.AllowAny,)
+
+class AvisoViewSet(viewsets.ModelViewSet):
+    queryset = Aviso.objects.all()
+    serializer_class = AvisoSerializer
     permission_classes = (permissions.AllowAny,)


### PR DESCRIPTION
# Cadastro de Aviso

- Cadastro da tabela aviso na API.
- Nenhum validador foi adicionado aos campos Titulo e Descricao, já que as regras de negócio atuais não restringem estes domínios
- Atributo data_cadastro usa o timestamp atual para inserir o aviso no BD, então o front não precisa de enviar este dado para a API. 
- Alteração na classe Validador, função **valida_nome** troca de nome para **possui_digito**. Este nome é mais significativo dado o comportamento da função. 